### PR TITLE
Show Ollama connection status in the UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useGrammarAnalysis } from './hooks/useGrammarAnalysis.js';
+import { useOllamaStatus } from './hooks/useOllamaStatus.js';
 import InputForm from './components/InputForm.jsx';
 import ResultBlock from './components/ResultBlock.jsx';
 import ThemeToggle from './components/ThemeToggle.jsx';
@@ -32,6 +33,9 @@ export default function App() {
 
   // Language directive is embedded in context — flows through to AI prompt
   const exerciseContext = `${BASE_CONTEXT} ${t.aiInstruction}`;
+
+  // Ollama connection status — checked on mount
+  const ollamaStatus = useOllamaStatus();
 
   // Grammar flow
   const {
@@ -82,6 +86,7 @@ export default function App() {
           onChange={setInputText}
           onSubmit={handleSubmit}
           isLoading={isLoading}
+          ollamaStatus={ollamaStatus}
           t={t}
         />
 

--- a/frontend/src/components/InputForm.jsx
+++ b/frontend/src/components/InputForm.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from 'react';
+import { Wifi, WifiOff } from 'lucide-react';
 
-export default function InputForm({ inputText, onChange, onSubmit, isLoading, t = {} }) {
-  const label       = t.inputLabel       || 'Your sentence';
-  const placeholder = t.inputPlaceholder || 'Type your Icelandic sentence here…';
-  const submitLabel = t.submitButton     || 'Analyse';
-  const loadingLabel = t.submitting      || 'Analysing…';
+export default function InputForm({ inputText, onChange, onSubmit, isLoading, ollamaStatus = 'checking', t = {} }) {
+  const label        = t.inputLabel        || 'Your sentence';
+  const placeholder  = t.inputPlaceholder  || 'Type your Icelandic sentence here…';
+  const submitLabel  = t.submitButton      || 'Analyse';
+  const loadingLabel = t.submitting        || 'Analysing…';
+  const errorMessage = t.ollamaUnreachable || 'Ollama is unreachable. Start the server with: ollama serve';
 
   const textareaRef = useRef(null);
 
@@ -23,33 +25,45 @@ export default function InputForm({ inputText, onChange, onSubmit, isLoading, t 
   function handleKeyDown(e) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (!isLoading && inputText.trim()) onSubmit();
+      if (!isLoading && inputText.trim() && ollamaStatus !== 'unreachable') onSubmit();
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} aria-busy={isLoading}>
-      {/* Input section */}
-      <div className="input-group">
-        <label htmlFor="grammar-input">{label}</label>
-        <textarea
-          ref={textareaRef}
-          id="grammar-input"
-          value={inputText}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={isLoading}
-          rows={1}
-          placeholder={placeholder}
-          style={{ minHeight: 'unset', resize: 'none', overflow: 'hidden' }}
-          required
-        />
-      </div>
+    <div className="input-form">
+      <form onSubmit={handleSubmit} aria-busy={isLoading}>
+        {/* Input section */}
+        <div className="input-group">
+          <label htmlFor="grammar-input">{label}</label>
+          <textarea
+            ref={textareaRef}
+            id="grammar-input"
+            value={inputText}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isLoading}
+            rows={1}
+            placeholder={placeholder}
+            style={{ minHeight: 'unset', resize: 'none', overflow: 'hidden' }}
+            required
+          />
+        </div>
 
-      {/* Submit */}
-      <button type="submit" disabled={isLoading || !inputText.trim()}>
-        {isLoading ? loadingLabel : submitLabel}
-      </button>
-    </form>
+        {/* Submit */}
+        <button type="submit" disabled={isLoading || !inputText.trim() || ollamaStatus === 'unreachable'}>
+          {isLoading ? loadingLabel : submitLabel}
+          {!isLoading && ollamaStatus === 'running' && (
+            <Wifi size={16} className="ollama-icon" />
+          )}
+          {!isLoading && ollamaStatus === 'unreachable' && (
+            <WifiOff size={16} className="ollama-icon ollama-icon--error" />
+          )}
+        </button>
+      </form>
+
+      {ollamaStatus === 'unreachable' && (
+        <p className="ollama-error">{errorMessage}</p>
+      )}
+    </div>
   );
 }

--- a/frontend/src/hooks/useOllamaStatus.js
+++ b/frontend/src/hooks/useOllamaStatus.js
@@ -1,0 +1,36 @@
+import { useState, useEffect, useCallback } from 'react';
+import { checkHealth } from '../services/api.js';
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useOllamaStatus() {
+  const [ollamaStatus, setOllamaStatus] = useState('checking');
+
+  const check = useCallback(() => {
+    checkHealth()
+      .then(data => setOllamaStatus(data.ollama === 'running' ? 'running' : 'unreachable'))
+      .catch(() => setOllamaStatus('unreachable'));
+  }, []);
+
+  useEffect(() => {
+    check();
+
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+
+    function onFocus() { check(); }
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') check();
+    }
+
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [check]);
+
+  return ollamaStatus;
+}

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -10,4 +10,5 @@ export const en = {
   aiInstruction: 'Respond in English. Use English headings.',
   footerLicense: 'GPL-3.0 License',
   footerGithub: 'Source code on GitHub',
+  ollamaUnreachable: 'Ollama is unreachable. Start the server with: ollama serve',
 };

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -10,4 +10,5 @@ export const fr = {
   aiInstruction: 'Réponds en français. Utilise des titres en français.',
   footerLicense: 'Licence GPL-3.0',
   footerGithub: 'Code source sur GitHub',
+  ollamaUnreachable: 'Ollama est inaccessible. Lancez le serveur avec : ollama serve',
 };

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -18,6 +18,14 @@ async function post(endpoint, body) {
 }
 
 // Public API
+export async function checkHealth() {
+  const response = await fetch(`${BASE_URL}/health`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!response.ok) throw new Error('Health check failed');
+  return response.json();
+}
+
 export function validateText(text, exerciseContext) {
   return post('/validate', { text, exerciseContext });
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -399,6 +399,31 @@ footer a:hover {
   text-decoration: underline;
 }
 
+/* ─── Ollama Status ───────────────────────────────────────────────────────── */
+
+.ollama-icon {
+  flex-shrink: 0;
+  margin-left: 6px;
+}
+
+.ollama-icon--error {
+  color: var(--color-error);
+}
+
+.ollama-error {
+  margin-top: var(--space-2);
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-error);
+  border-radius: var(--radius-md);
+}
+
+[data-theme="dark"] .ollama-error {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-error);
+  background-color: color-mix(in srgb, var(--color-error) 12%, transparent);
+}
+
 /* ─── Loader ──────────────────────────────────────────────────────────────── */
 
 @keyframes spin {
@@ -449,6 +474,10 @@ footer a:hover {
   form button[type="submit"] {
     width: 190px;
     flex-shrink: 0;
+  }
+
+  .ollama-error {
+    width: 100%;
   }
 
   [role="alert"] > div,

--- a/src/routes/apiRoutes.js
+++ b/src/routes/apiRoutes.js
@@ -1,11 +1,21 @@
 import { Router } from 'express';
 import { validate } from '../controllers/validationController.js';
 import { analyzeText, analyzeTextStream } from '../controllers/analyzeController.js';
+import { OLLAMA_BASE_URL } from '../config/config.js';
 
 const router = Router();
 
-// Health check
-router.get('/health', (req, res) => res.json({ status: 'ok' }));
+// Health check — also probes Ollama connectivity
+router.get('/health', async (req, res) => {
+  try {
+    const response = await fetch(`${OLLAMA_BASE_URL}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    res.json({ status: 'ok', ollama: response.ok ? 'running' : 'unreachable' });
+  } catch {
+    res.json({ status: 'ok', ollama: 'unreachable' });
+  }
+});
 
 // Grammar endpoints
 router.post('/validate', validate);


### PR DESCRIPTION
When Ollama is not running or unreachable, the app currently fails silently until the user submits a sentence and receives a generic error. There is no proactive feedback.

### Proposed solution:

- On app mount, call the existing `GET /api/health` endpoint and check whether Ollama is reachable
- Display a small status badge near the validation button's text:
  - wifi icon: Ollama is running
  - wifi-off icon (red): Ollama is unreachable — with a short message explaining the issue and pointing to ollama serve
- Re-check periodically or on focus to detect reconnections